### PR TITLE
GHA migration - Ci-Cd workflow added

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,71 @@
+name: ci-cd
+on:
+  push:
+    branches:
+      - feature/modules_support      
+  pull_request:
+    branches:
+      - feature/modules_support
+
+jobs:
+  build-and-test:
+    name: Build and run Tests
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go version
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+
+      - name: Go mod
+        run: go mod tidy
+
+      - name: Execute tests
+        run: go test ./... -count=1 -race
+
+      - name: SonarQube Scan (Push)
+        if: github.event_name == 'push'
+        uses: SonarSource/sonarcloud-github-action@v1.5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.projectVersion=${{ env.VERSION }}
+            -Dsonar.exclusions='**/*_test.go,**/vendor/**,**/testdata/*'
+            -Dsonar.go.coverage.reportPaths=coverage.out
+            -Dsonar.links.ci="https://github.com/splitio/${{ github.event.repository.name }}/actions"
+            -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
+
+      - name: SonarQube Scan (Pull Request)
+        if: github.event_name == 'pull_request'
+        uses: SonarSource/sonarcloud-github-action@v1.5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.projectVersion=${{ env.VERSION }}
+            -Dsonar.exclusions='**/*_test.go,**/vendor/**,**/testdata/*'
+            -Dsonar.go.coverage.reportPaths=coverage.out
+            -Dsonar.links.ci="https://github.com/splitio/${{ github.event.repository.name }}/actions"
+            -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: go
-
-go:
-  - 1.x
-
-script:
-  - go test ./... -v -coverprofile=coverage.out -race


### PR DESCRIPTION
What did you accomplish?
Adding new ci-cd workflow for GHA in order to migrate out of TravisCI

How do we test the changes introduced in this PR?
Verifying that the build pass ok in the GHA actions tab and checking SonarQube